### PR TITLE
Fixes dumping money bags into IDs

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -158,10 +158,12 @@
 		var/obj/item/storage/bag/money/money_bag = W
 		var/list/money_contained = money_bag.contents
 
-		var/money_added = mass_insert_money(money_contained, user)
+		for (var/money in money_contained) // money bag contents are guaranteed to be money
+			registered_account.adjust_money(money.get_item_credit_value())
 
-		if (money_added)
+		if (money_contained.len)
 			to_chat(user, "<span class='notice'>You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account.</span>")
+		QDEL_LIST(money_contained)
 		return
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
**This wasn't tested at all.**
## About The Pull Request
Makes the ID attackby get all the money in a money bag by not looking at the specific type.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So you don't have to take coins and insert them one by one into the ID.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can now properly dump money bag contents into an ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
